### PR TITLE
Fix: Add datetime cast for ends_at column

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -25,6 +25,10 @@
             'updated_at',
         ];
 
+        protected array $casts = [
+            'ends_at' => 'datetime'
+        ];
+
         /**
          * Get the user that owns the subscription.
          *


### PR DESCRIPTION
## Issue
When using the package with MySQL, I encountered the following error:
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2025-04-28T06:47:00.000Z' for column 'ends_at'

This happens because the `ends_at` column is receiving ISO 8601 formatted dates that MySQL cannot properly interpret without casting.

## Solution
I've added a simple datetime cast to the model:
```php
protected array $casts = [
    'ends_at' => 'datetime'
];
This ensures Laravel properly formats the datetime before sending it to the database, preventing the SQL format error.

Testing

I've tested this fix with:
MySQL 8.0
Laravel 10.x
PHP 8.2